### PR TITLE
[fix] local docker setting delete db migrate

### DIFF
--- a/config/docker/entrypoint.sh
+++ b/config/docker/entrypoint.sh
@@ -13,5 +13,5 @@ fi
 
 autossh -i ${SSH_PEM_KEY} -M 33306 -4fNL ${DATABASE_PORT}:${RDS_HOST}:${DATABASE_PORT} ${SSH_USER}@${SSH_HOST}
 
-python manage.py migrate
+#python manage.py migrate
 python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
- 로컬 docker 세팅에서 db migrate 자동화 한거 지움 (로컬은 서로 작업이 다른 순간이 있는데, 매번 migrate시 충돌이 있을 수 있기 때문)
- 로컬 db migrate는 develop 브랜치에서 수동으로 관리하는 것으로 