### PR TITLE
[chore] svg image package & modify serializer

### DIFF
--- a/diet/serializers.py
+++ b/diet/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from diet.models import DietAllergy, Filter, FilterCategory, Data
+from django_svg_image_form_field import SvgAndImageFormField
 
 
 class DietAllergySerializer(serializers.ModelSerializer):
@@ -17,27 +18,17 @@ class FilterCategorySerializer(serializers.ModelSerializer):
 
 class FilterSerializer(serializers.ModelSerializer):
     category = serializers.SerializerMethodField(read_only=True)
-    image = serializers.SerializerMethodField(read_only=True)
-    image_selected = serializers.SerializerMethodField(read_only=True)
 
     def get_category(self, obj):
         return obj.category.id
 
-    def get_image(self, obj):
-        request = self.context.get('request')
-        if obj.image:
-            return request.build_absolute_uri(obj.image.url)
-        return None
-
-    def get_image_selected(self, obj):
-        request = self.context.get('request')
-        if obj.image_selected:
-            return request.build_absolute_uri(obj.image_selected.url)
-        return None
-
     class Meta:
         model = Filter
         fields = ['id', 'name', 'category', 'image', 'image_selected']
+        field_classes = {
+            'image': SvgAndImageFormField,
+            'image_selected': SvgAndImageFormField,
+        }
 
 
 class DietDataSerializer(serializers.ModelSerializer):
@@ -45,13 +36,6 @@ class DietDataSerializer(serializers.ModelSerializer):
     ingredient = serializers.JSONField(default=list)
     recipe = serializers.JSONField(default=list)
     tip = serializers.JSONField(default=list)
-    image = serializers.SerializerMethodField(read_only=True)
-
-    def get_image(self, obj):
-        request = self.context.get('request')
-        if obj.image:
-            return request.build_absolute_uri(obj.image.url)
-        return None
 
     def get_menu(self, obj):
         return obj.menu
@@ -60,18 +44,16 @@ class DietDataSerializer(serializers.ModelSerializer):
         model = Data
         fields = ['id', 'name', 'image', 'menu', 'carbohydrate', 'protein', 'province', 'salt', 'total_calorie', 'ingredient',
                   'recipe', 'tip', 'user_id', 'type_id', 'flavor_id', 'carbohydrate_type_id']
+        field_classes = {
+            'image': SvgAndImageFormField,
+        }
 
 
 # 식단 정보 간략하게
 class DietSimpleSerializer(serializers.ModelSerializer):
-    image = serializers.SerializerMethodField(read_only=True)
-
-    def get_image(self, obj):
-        request = self.context.get('request')
-        if obj.image:
-            return request.build_absolute_uri(obj.image.url)
-        return None
-
     class Meta:
         model = Data
         fields = ['id', 'name', 'image']
+        field_classes = {
+            'image': SvgAndImageFormField,
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 asgiref==3.6.0
+defusedxml==0.7.1
 Django==3.2.16
 django-cors-headers==3.13.0
 django-environ==0.9.0
 django-filter==22.1
+django-svg-image-form-field==1.0.1
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
 gunicorn==20.1.0
@@ -12,5 +14,3 @@ PyJWT==2.6.0
 pytz==2022.7
 PyYAML==6.0
 sqlparse==0.4.3
-
-djangorestframework~=3.14.0


### PR DESCRIPTION
### 작업사항
- 필터이미지 (svg 파일) 관리하기 위해 svgimage 패키지 설치

### 수정사항
- image url 변환 시, serializer에서 image 메소드필드로 만들었던 부분 삭제 (메소드필드로 정의하지 않아도, 매개로 context={"request":request} 를 넘겨주면 잘 작동하는 것 확인) 